### PR TITLE
collect anonymous contributors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,4 @@ jobs:
       - uses: julia-actions/julia-runtest@latest
         env:
           JULIA_NUM_THREADS: "2"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - "^1.6.0-0"
+          - "1.6"
           - "nightly"
         os:
           - ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: "^1.6.0-0"
+          version: "1.6"
       - name: Cache artifacts
         uses: actions/cache@v2
         env:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -217,8 +217,8 @@ julia> DataFrame(result.lines_of_code)
 If the package repository is hosted on GitHub and you can use [GitHub
 authentication](@ref), the list of contributors is added to the `contributors`
 field of the `Package` object.  This is a table which includes the GitHub username ("login") and
-the GitHub ID ("id") for contributors identified as GitHub "users", and the "name" for contributers
-identified as "Anonymous" contributers, as well as the number of contributions provided by that user to
+the GitHub ID ("id") for contributors identified as GitHub "users", and the "name" for contributors
+identified as "Anonymous" contributors, as well as the number of contributions provided by that user to
 the repository. This is the data returned from the GitHub API, and there may be people for which
 some of their contributions are marked as from an anonymous user (possibly more than one!) and
 some of their contributions are associated to their GitHub username.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -126,7 +126,7 @@ struct Package
     license_files::Vector{@NamedTuple{license_filename::String, licenses_found::Vector{String}, license_file_percent_covered::Float64}} # a table of all possible license files
     licenses_in_project::Vector{String} # any licenses in the `license` key of the Project.toml
     lines_of_code::Vector{@NamedTuple{directory::String, language::Symbol, sublanguage::Union{Nothing, Symbol}, files::Int, code::Int, comments::Int, blanks::Int}} # table of lines of code
-    contributors::Dict{String,Int} # Dictionary contributors => contributions
+    contributors::Vector{@NamedTuple{login::Union{String,Missing}, id::Union{Int,Missing}, name::Union{String,Missing}, type::String, contributions::Int}} # table of contributor data
 end
 ```
 
@@ -216,41 +216,41 @@ julia> DataFrame(result.lines_of_code)
 
 If the package repository is hosted on GitHub and you can use [GitHub
 authentication](@ref), the list of contributors is added to the `contributors`
-field of the `Package` object.  This is a dictionary whose keys are the GitHub
-usernames of the contributors, and the values are the corresponding numbers of
-contributions in that repository.
+field of the `Package` object.  This is a table which includes the GitHub username ("login") and
+the GitHub ID ("id") for contributors identified as GitHub "users", and the "name" for contributers
+identified as "Anonymous" contributers, as well as the number of contributions provided by that user to
+the repository. This is the data returned from the GitHub API, and there may be people for which
+some of their contributions are marked as from an anonymous user (possibly more than one!) and
+some of their contributions are associated to their GitHub username.
 
 ```julia
 julia> using PackageAnalyzer, DataFrames
 
 julia> result = analyze("DataFrames");
 
-julia> users = collect(keys(result.contributors));
+julia> df = DataFrame(result.contributors);
 
-julia> df = DataFrame(:User => users, :Contributions => map(x -> result.contributors[x], users));
-
-julia> sort!(df, [:Contributions, :User], rev=true)
-165×2 DataFrame
- Row │ User               Contributions
-     │ String             Int64
-─────┼──────────────────────────────────
-   1 │ johnmyleswhite               431
-   2 │ bkamins                      364
-   3 │ powerdistribution            232
-   4 │ nalimilan                    220
-   5 │ garborg                      173
-   6 │ quinnj                       101
-   7 │ simonster                     87
-   8 │ cjprybol                      50
-   9 │ alyst                         48
-  10 │ dmbates                       47
-  11 │ tshort                        39
-  12 │ doobwa                        32
-  13 │ HarlanH                       32
-  14 │ kmsquire                      30
-  15 │ pdeffebach                    19
-  16 │ ararslan                      19
-  ⋮  │         ⋮                ⋮
+julia> sort!(df, :contributions, rev=true)
+183×5 DataFrame
+ Row │ login              id        name           type       contributions 
+     │ String?            Int64?    String?        String     Int64         
+─────┼──────────────────────────────────────────────────────────────────────
+   1 │ johnmyleswhite        22064  missing        User                 431
+   2 │ bkamins             6187170  missing        User                 381
+   3 │ powerdistribution   5247292  missing        User                 232
+   4 │ nalimilan           1120448  missing        User                 221
+   5 │ garborg             2823840  missing        User                 173
+   6 │ quinnj              2896623  missing        User                 101
+   7 │ simonster            470884  missing        User                  87
+   8 │ missing             missing  Harlan Harris  Anonymous             67
+   9 │ cjprybol            3497642  missing        User                  50
+  10 │ alyst                348591  missing        User                  48
+  11 │ dmbates              371258  missing        User                  47
+  12 │ tshort               636420  missing        User                  39
+  13 │ doobwa                79467  missing        User                  32
+  14 │ HarlanH              130809  missing        User                  32
+  15 │ kmsquire             223250  missing        User                  30
+  ⋮  │         ⋮             ⋮            ⋮            ⋮            ⋮
 ```
 
 ## GitHub authentication

--- a/src/PackageAnalyzer.jl
+++ b/src/PackageAnalyzer.jl
@@ -122,8 +122,8 @@ function Base.show(io::IO, p::Package)
             body *= "    * OSI approved: $(all(is_osi_approved, p.licenses_in_project))\n"
         end
         if !isempty(p.contributors)
-            n_anon = count_contributers(p; type="Anonymous")
-            body *= "  * number of contributors: $(count_contributers(p)) (and $(n_anon) anonymous contributors)\n"
+            n_anon = count_contributors(p; type="Anonymous")
+            body *= "  * number of contributors: $(count_contributors(p)) (and $(n_anon) anonymous contributors)\n"
         end
         body *= """
               * has documentation: $(p.docs)
@@ -549,8 +549,8 @@ function contribution_table(repo_name; auth)
     return parse_contributions.(GitHub.contributors(GitHub.repo(repo_name; auth); auth, params=Dict("anon"=>"true"))[1])
 end
 
-count_contributers(table; type="User") = count(row.type == type for row in table)
-count_contributers(pkg::Package; kwargs...) = count_contributers(pkg.contributors; kwargs...)
+count_contributors(table; type="User") = count(row.type == type for row in table)
+count_contributors(pkg::Package; kwargs...) = count_contributors(pkg.contributors; kwargs...)
 
 function parse_contributions(c)
     contrib = c["contributor"]

--- a/src/PackageAnalyzer.jl
+++ b/src/PackageAnalyzer.jl
@@ -530,11 +530,6 @@ function analyze_path(dir::AbstractString; repo = "", reachable=true, subdir="",
     contributors = if !(auth isa GitHub.AnonymousAuth) && occursin("github.com", repo)
         Base.sleep(sleep)
         repo_name = replace(replace(repo, r"^https://github\.com/" => ""), r"\.git$" => "")
-        # Exclude commits made by known bots, including `@staticfloat`
-        #   130920   => staticfloat (when he has one commit, it's most likely an automated one)
-        #   30578772 => femtocleaner[bot]
-        #   41898282 => github-actions[bot]
-        #   50554310 => TagBot
         contribution_table(repo_name; auth)
     else
         ContributionTableElType[]

--- a/src/PackageAnalyzer.jl
+++ b/src/PackageAnalyzer.jl
@@ -450,7 +450,7 @@ function analyze(name_or_dir_or_url::AbstractString; repo = "", reachable=true, 
 end
 
 """
-    analyze(m::Module) -> Package
+    analyze(m::Module; kwargs...) -> Package
 
 If you want to analyze a package which is already loaded in the current session,
 you can simply call `analyze`, which uses `pkgdir` to determine its source code:
@@ -474,7 +474,7 @@ Package DataFrames:
     * GitHub Actions
 ```
 """
-analyze(m::Module) = analyze_path(pkgdir(m))
+analyze(m::Module; kwargs...) = analyze_path(pkgdir(m); kwargs...)
 
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,7 +36,7 @@ const auth = GitHub.AnonymousAuth()
     @test cuba.drone
     @test !polyroots.docs # Documentation is in the README!
     # We can also use broadcasting!
-    @test Set(results) == Set(analyze.(packages))
+    @test Set(results) == Set(analyze.(packages; auth))
 
     # Test `analyze!` directly
     mktempdir() do root

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Test, UUIDs
 using PackageAnalyzer
 using PackageAnalyzer: parse_project, RegistryEntry
 using JLLWrappers
+using GitHub
 
 get_libpath() = get(ENV, JLLWrappers.LIBPATH_env, nothing)
 const orig_libpath = get_libpath()
@@ -38,7 +39,7 @@ const orig_libpath = get_libpath()
     # Test `analyze!` directly
     mktempdir() do root
         measurements2 = analyze!(root, RegistryEntry(joinpath(general, "M", "Measurements")))
-        @test measurements == measurements2
+        @test isequal(measurements, measurements2)
         @test isdir(joinpath(root, "eff96d63-e80a-5855-80a2-b1b0885c5ab7")) # not cleaned up yet
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -179,8 +179,8 @@ end
         pkg = analyze("DataFrames")
         @test pkg.contributors isa Vector{<:NamedTuple}
         @test length(pkg.contributors) > 160 # ==183 right now, and it shouldn't go down...
-        @test PackageAnalyzer.count_contributers(pkg) > 150
-        @test PackageAnalyzer.count_contributers(pkg; type="Anonymous") > 10
+        @test PackageAnalyzer.count_contributors(pkg) > 150
+        @test PackageAnalyzer.count_contributors(pkg; type="Anonymous") > 10
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -171,6 +171,18 @@ end
     @test occursin("* OSI approved: true", str)
 end
 
+@testset "Contributors" begin
+    if PackageAnalyzer.github_auth() isa GitHub.AnonymousAuth
+        @warn "Skipping contributors tests since `PackageAnalyzer.github_auth()` is anonymous"
+    else
+        pkg = analyze("DataFrames")
+        @test pkg.contributors isa Vector{<:NamedTuple}
+        @test length(pkg.contributors) > 160 # ==183 right now, and it shouldn't go down...
+        @test PackageAnalyzer.count_contributers(pkg) > 150
+        @test PackageAnalyzer.count_contributers(pkg; type="Anonymous") > 10
+    end
+end
+
 @testset "Thread-safety" begin
     # Make sure none of the above commands leaks LD_LIBRARY_PATH.  This test
     # should be executed at the very end of the test suite.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,8 @@ using GitHub
 get_libpath() = get(ENV, JLLWrappers.LIBPATH_env, nothing)
 const orig_libpath = get_libpath()
 
+const auth = GitHub.AnonymousAuth()
+
 @testset "PackageAnalyzer" begin
     general = general_registry()
     @test isdir(general)
@@ -16,7 +18,7 @@ const orig_libpath = get_libpath()
     @test isdir(find_package("Flux").path)
     # Test some properties of the `Measurements` package.  NOTE: they may change
     # in the future!
-    measurements = analyze(RegistryEntry(joinpath(general, "M", "Measurements")))
+    measurements = analyze(RegistryEntry(joinpath(general, "M", "Measurements")); auth)
     @test measurements.uuid == UUID("eff96d63-e80a-5855-80a2-b1b0885c5ab7")
     @test measurements.reachable
     @test measurements.docs
@@ -27,7 +29,7 @@ const orig_libpath = get_libpath()
     packages = [RegistryEntry(joinpath(general, p...)) for p in (("C", "Cuba"), ("P", "PolynomialRoots"))]
     @test Set(packages) == Set(find_packages("Cuba", "PolynomialRoots")) == Set(find_packages(["Cuba", "PolynomialRoots"]))
     @test packages ⊆ find_packages()
-    results = analyze(packages)
+    results = analyze(packages; auth)
     cuba, polyroots = results
     @test length(filter(p -> p.reachable, results)) == 2
     @test length(filter(p -> p.runtests, results)) == 2
@@ -38,14 +40,14 @@ const orig_libpath = get_libpath()
 
     # Test `analyze!` directly
     mktempdir() do root
-        measurements2 = analyze!(root, RegistryEntry(joinpath(general, "M", "Measurements")))
+        measurements2 = analyze!(root, RegistryEntry(joinpath(general, "M", "Measurements")); auth)
         @test isequal(measurements, measurements2)
         @test isdir(joinpath(root, "eff96d63-e80a-5855-80a2-b1b0885c5ab7")) # not cleaned up yet
     end
 end
 
 @testset "`analyze`" begin
-    for pkg in (analyze(PackageAnalyzer), analyze("https://github.com/giordano/PackageAnalyzer.jl"), analyze(joinpath(@__DIR__, "..")))
+    for pkg in (analyze(PackageAnalyzer; auth), analyze("https://github.com/giordano/PackageAnalyzer.jl"; auth), analyze(joinpath(@__DIR__, ".."); auth))
         @test pkg.uuid == UUID("e713c705-17e4-4cec-abe0-95bf5bf3e10c")
         @test pkg.reachable == true # default
         @test pkg.docs == true
@@ -68,7 +70,7 @@ end
 
     # the tests folder isn't a package!
     # But this helps catch issues in error paths for when things go wrong
-    bad_pkg = analyze(".")
+    bad_pkg = analyze("."; auth)
     @test bad_pkg.repo == ""
     @test bad_pkg.uuid == UUID(UInt128(0))
     @test !bad_pkg.cirrus
@@ -76,17 +78,17 @@ end
     @test isempty(bad_pkg.licenses_in_project)
 
     # The argument is a package name
-    pkg = analyze("Pluto")
+    pkg = analyze("Pluto"; auth)
     # Just make sure we got the UUID correctly and some statistics are collected.
     @test pkg.uuid == UUID("c3e4b0f8-55cb-11ea-2926-15256bba5781")
     @test !isempty(pkg.license_files)
     @test !isempty(pkg.lines_of_code)
     # The argument looks like a package name but it isn't a registered package
-    @test_logs (:error, r"Could not find package in registry") match_mode=:any @test_throws ArgumentError analyze("license_in_project")
+    @test_logs (:error, r"Could not find package in registry") match_mode=:any @test_throws ArgumentError analyze("license_in_project"; auth)
 end
 
 @testset "`find_packages` with `analyze`" begin
-    results = analyze(find_packages("DataFrames", "Flux")) # this method is threaded
+    results = analyze(find_packages("DataFrames", "Flux"); auth) # this method is threaded
     @test results isa Vector{PackageAnalyzer.Package}
     @test length(results) == 2
     # DataFrames currently has 16k LoC; Flux has 5k. Let's check that they aren't mixed up
@@ -97,12 +99,12 @@ end
     @test PackageAnalyzer.count_julia_loc(results[2].lines_of_code, "src") < 14000
 
 
-    results = analyze(find_packages("DataFrames"))
+    results = analyze(find_packages("DataFrames"); auth)
     @test results isa Vector{PackageAnalyzer.Package}
     @test length(results) == 1
     @test results[1].name == "DataFrames"
 
-    result = analyze(find_package("DataFrames"))
+    result = analyze(find_package("DataFrames"); auth)
     @test result isa PackageAnalyzer.Package
     @test result.name == "DataFrames"
 end
@@ -111,7 +113,7 @@ end
     # we check the error path here; the success path is covered by other tests.
     # This also makes sure trying to clone the repo doesn't prompt for
     # username/password
-    result = PackageAnalyzer.analyze_path!(mktempdir(), "https://github.com/giordano/DOES_NOT_EXIST.jl")
+    result = PackageAnalyzer.analyze_path!(mktempdir(), "https://github.com/giordano/DOES_NOT_EXIST.jl"; auth)
     @test result isa PackageAnalyzer.Package
     @test !result.reachable
     @test isempty(result.name)
@@ -119,7 +121,7 @@ end
 
 @testset "`subdir` support" begin
     snoop_core_path = only(find_packages("SnoopCompileCore"))
-    snoop_core = analyze(snoop_core_path)
+    snoop_core = analyze(snoop_core_path; auth)
     @test !isempty(snoop_core.subdir)
     @test snoop_core.name == "SnoopCompileCore" # this test would fail if we were parsing the wrong Project.toml (that of SnoopCompile)
     # This tests that we find licenses in the subdir and put them first,
@@ -131,13 +133,13 @@ end
     # the Julia code in SnoopCompileCore. One, we can ask SnoopCompile for the lines of Julia code in its
     # top-level directory `SnoopCompileCore`. Two, we can ask SnoopCompileCore for all of it's
     # Julia code.
-    snoop_compile = analyze(find_package("SnoopCompile"))
+    snoop_compile = analyze(find_package("SnoopCompile"); auth)
     snoop_compile_count_for_core = sum(row.code for row in snoop_compile.lines_of_code if row.language == :Julia && row.sublanguage===nothing && row.directory == "SnoopCompileCore")
     snoop_core_count = sum(row.code for row in snoop_core.lines_of_code if row.language == :Julia && row.sublanguage===nothing)
     @test snoop_core_count == snoop_compile_count_for_core
 
     # this package doesn't exist in the repo anymore; let's ensure it doesn't throw
-    snoop_compile_analysis = analyze(find_package("SnoopCompileAnalysis"))
+    snoop_compile_analysis = analyze(find_package("SnoopCompileAnalysis"); auth)
     @test isempty(snoop_compile_analysis.lines_of_code)
 end
 
@@ -167,7 +169,7 @@ end
 
 @testset "`show`" begin
     # this is mostly to test that `show` doesn't error
-    str = sprint(show, analyze(pkgdir(PackageAnalyzer)))
+    str = sprint(show, analyze(pkgdir(PackageAnalyzer); auth))
     @test occursin("* uuid: e713c705-17e4-4cec-abe0-95bf5bf3e10c", str)
     @test occursin("* OSI approved: true", str)
 end


### PR DESCRIPTION
For repos with > 500 contributors, the GH api only returns 500 (though it seems like sometimes fewer, e.g. 404 for JuliaLang/julia).

This PR passes `anon=true` so that GH returns us all the contributors, but for some it will return GH info like their GH id and login, and for others it will return just a name and email, which is presumably not deduplicated if one used multiple names/emails but with the same GH identity.

To handle the variety of responses, I switched the object we store to a table that uses missing entries for id/login or name/email depending on what we have.

Draft since it isn't totally clear if we want to go this way (now we probably have duplicate entries instead of missing entries) and I haven't updated tests or docs.

Example:
```julia
julia> AnalyzeRegistry.contribution_table("JuliaLang/julia"; auth) |> DataFrame
1277×6 DataFrame
  Row │ login            id       name             email                              type       contributions 
      │ String?          Int64?   String?          String?                            String     Int64         
──────┼────────────────────────────────────────────────────────────────────────────────────────────────────────
    1 │ JeffBezanson      744556  missing          missing                            User                9721
    2 │ StefanKarpinski   153596  missing          missing                            User                4238
    3 │ missing          missing  Jameson Nash     jameson@juliacomputing.com         Anonymous           3429
    4 │ ViralBShah        744411  missing          missing                            User                2830
    5 │ Keno             1291671  missing          missing                            User                2019
    6 │ tkelman          5934628  missing          missing                            User                1724
    7 │ timholy          1525481  missing          missing                            User                1582
    8 │ yuyichao          712232  missing          missing                            User                1361
    9 │ kshyatt           828643  missing          missing                            User                1145
  ⋮   │        ⋮            ⋮            ⋮                         ⋮                      ⋮            ⋮
 1270 │ missing          missing  wfrgra           wfrgra@gmail.com                   Anonymous              1
 1271 │ missing          missing  wgmitchener      noreply@github.com                 Anonymous              1
 1272 │ missing          missing  willywalters5    41460481+willywalters5@users.nor…  Anonymous              1
 1273 │ missing          missing  woclass          inkydragon@users.noreply.github.…  Anonymous              1
 1274 │ missing          missing  wooglooskr       paul@milovanov.ca                  Anonymous              1
 1275 │ missing          missing  wschildbach      wschildbach@fermi.franken.de       Anonymous              1
 1276 │ missing          missing  yuebanyishenqiu  thisispwj@outlook.com              Anonymous              1
 1277 │ missing          missing  zsoerenm         zsoerenm@hotmail.de                Anonymous              1
                                                                                              1260 rows omitted
```