### PR TITLE
Don't emit warnings when not finding stdlibs in `find_packages`

### DIFF
--- a/src/PackageAnalyzer.jl
+++ b/src/PackageAnalyzer.jl
@@ -176,9 +176,9 @@ function find_package(pkg::AbstractString; registry=general_registry())
     registry_entries = find_packages([pkg]; registry)
     if isempty(registry_entries)
         if pkg ∈ values(STDLIBS)
-            error("Could not find standard library $pkg in registry")
+            throw(ArgumentError("Standard library $pkg not present in registry"))
         else
-            error("Could not find $pkg in registry")
+            throw(ArgumentError("$pkg not found in registry"))
         end
     end
     return only(registry_entries)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,6 +107,15 @@ end
     result = analyze(find_package("DataFrames"); auth)
     @test result isa PackageAnalyzer.Package
     @test result.name == "DataFrames"
+
+    # Don't error when not finding stdlibs in `find_packages`
+    @test_logs find_packages("Dates")
+    # But we do emit a warning log for non-existent package `Abc`
+    @test_logs (:error,) find_packages("Abc")
+
+    # Check we get a nice error for `find_package`
+    @test_throws ErrorException("Could not find standard library Dates in registry") find_package("Dates")
+    @test_throws ErrorException("Could not find Abc in registry") find_package("Abc")
 end
 
 @testset "`analyze_path!`" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -114,8 +114,8 @@ end
     @test_logs (:error,) find_packages("Abc")
 
     # Check we get a nice error for `find_package`
-    @test_throws ErrorException("Could not find standard library Dates in registry") find_package("Dates")
-    @test_throws ErrorException("Could not find Abc in registry") find_package("Abc")
+    @test_throws ArgumentError("Standard library Dates not present in registry") find_package("Dates")
+    @test_logs (:error,)  @test_throws ArgumentError("Abc not found in registry") find_package("Abc")
 end
 
 @testset "`analyze_path!`" begin


### PR DESCRIPTION
This allows things like
```julia
using PackageAnalyzer, PkgDeps, DataFrames
DataFrame(analyze(find_packages(keys(dependencies("DataFrames")))))
```
to not emit warnings.