### PR TITLE
update serialization recommendation in docs

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,4 +5,4 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
 Arrow = "1.3"
-Documenter = "~0.26"
+Documenter = "0.27"

--- a/docs/src/serialization.md
+++ b/docs/src/serialization.md
@@ -1,23 +1,12 @@
 ## Saving results
 
-In just four lines of code, we can setup serialization of collections of PackageAnalyzer's `Package` object to Apache arrow tables:
+Since a `Vector{Package}` is a Tables.jl-compatible row table, one does not need to do anything special
+to save the results as a table. For example,
 
 ```@repl 1
-using PackageAnalyzer
-using Arrow # v1.3+
-ArrowTypes.arrowname(::Type{PackageAnalyzer.Package}) = Symbol("JuliaLang.PackageAnalyzer.Package")
-ArrowTypes.JuliaType(::Val{Symbol("JuliaLang.PackageAnalyzer.Package")}) = PackageAnalyzer.Package
-save(path, packages) = Arrow.write(path, (; packages))
-load(path) = copy(Arrow.Table(path).packages)
-```
-
-Then we can do e.g.
-
-```@repl 1
+using DataFrames, Arrow, PackageAnalyzer
 results = analyze(find_packages("DataFrames", "Flux"));
-save("packages.arrow", results)
-roundtripped_results = load("packages.arrow")
+Arrow.write("packages.arrow", results)
+roundtripped_results = DataFrame(Arrow.Table("packages.arrow"))
 rm("packages.arrow") # hide
 ```
-
-Note that even if future versions of PackageAnalyzer change the layout of `Package`'s and you forget the version used to serialize the results, you can use the same `load` function *without* defining the `ArrowTypes.JuliaType` method in the Julia session in order to deserialize the results back as `NamedTuple`'s (instead of as `Package`s), providing some amount of robustness.


### PR DESCRIPTION
I think this is a better way to handle serialization. The difference is that we don't get `Package` objects back out post-serialization, instead we get a table.

The advantage is that if we add more fields to `Package`, this kind of serialization won't break, since we aren't trying to fit the result of deserialization back into a `Package` object. We are just getting a table, and it's easy to combine tables with more or less columns (e.g. `DataFrames` has `vcat` and `append!` methods with `cols=:union` option to union all the columns).

The disadvantage is that again you aren't getting a `Package` back, just the contents of the package as a row of a table, so you'd need to do some more work to reconstruct the Package object if that's what you really wanted. However, in our usage that definitely isn't what we actually want-- we just want the row of the table. And I expect that's true for most uses of serializing Package objects.

Note that it is not too hard to combine results saved the old way and this new way; we just check if the table has a single column named `packages` or not. If it does, we unpack that and convert to a table same as before. If it has more columns then we assume it's the new kind and just take the table as-is directly.