### PR TITLE
update to use RegistryInstances

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PackageAnalyzer"
 uuid = "e713c705-17e4-4cec-abe0-95bf5bf3e10c"
 authors = ["Mosè Giordano <mose@gnu.org>"]
-version = "0.1.1"
+version = "0.2.0"
 
 [deps]
 Git = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
@@ -10,6 +10,7 @@ JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 LicenseCheck = "726dbf0d-6eb6-41af-b36c-cd770e0f00cc"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+RegistryInstances = "2792f1a3-b283-48e8-9a74-f99dce5104f3"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Tokei_jll = "3ac119c9-1236-5556-b556-adc8150b0244"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
@@ -19,6 +20,7 @@ Git = "1.2.1"
 GitHub = "5.4"
 JSON3 = "1.5.1"
 LicenseCheck = "0.2"
+RegistryInstances = "0.1"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PackageAnalyzer"
 uuid = "e713c705-17e4-4cec-abe0-95bf5bf3e10c"
 authors = ["Mosè Giordano <mose@gnu.org>"]
-version = "0.2.0"
+version = "1.0.0"
 
 [deps]
 Git = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -32,10 +32,9 @@ a package in a locally-installed registry (the General registry is checked by de
 *NOTE*: the Git repository of the package will be cloned, in order to inspect
 its content.
 
-You can also pass a [`RegistryEntry`](@ref), a simple datastructure which points
-to the directory of the package in the registry, where the file `Package.toml`
-is stored.  The function [`find_package`](@ref) gives you the
-[`RegistryEntry`](@ref) of a package in your local copy of any registry, by
+You can also pass a [`PkgEntry`](@ref) from RegistryInstances.jl. 
+The function [`find_package`](@ref) gives you the
+[`PkgEntry`](@ref) of a package in your local copy of any registry, by
 default the [General registry](https://github.com/JuliaRegistries/General).
 `find_package` is invoked automatically when you pass the name of a package.
 
@@ -146,7 +145,7 @@ To run the analysis for multiple packages you can either use broadcasting
 ```julia
 analyze.(registry_entries)
 ```
-or use the method `analyze(registry_entries::AbstractVector{<:RegistryEntry})` which
+or use the method `analyze(pkg_entries::AbstractVector{<:PkgEntry})` which
 runs the analysis with multiple threads.
 
 You can use the function [`find_packages`](@ref) to find all packages in a given
@@ -166,6 +165,8 @@ Do not abuse this function! Consider using the in-place function `analyze!(root,
 
 !!! warning
     Cloning all the repos in General will take more than 20 GB of disk space and can take up to a few hours to complete.
+
+You can use RegistryInstance's `reachable_registries()` function to find other `RegistryInstance` objects to use for the `registry` keyword argument.
 
 ## License information
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,10 +22,11 @@ const auth = GitHub.AnonymousAuth()
     @test measurements.runtests
     @test !measurements.buildkite
     @test !isempty(measurements.lines_of_code)
+    packages = find_packages("Cuba", "PolynomialRoots")
     # Test results of a couple of packages.  Same caveat as above
     uuids = only.(uuids_from_name.(Ref(general), ["Cuba", "PolynomialRoots"]))
     # We compare by UUID, since other fields may be initialized or not
-    @test Set(uuids) == Set([x.uuid for x in find_packages("Cuba", "PolynomialRoots")]) == Set([x.uuid for x in find_packages(["Cuba", "PolynomialRoots"])])
+    @test Set(uuids) == Set([x.uuid for x in packages]) == Set([x.uuid for x in find_packages(["Cuba", "PolynomialRoots"])])
     @test uuids ⊆ [x.uuid for x in find_packages()]
     results = analyze(packages; auth)
     cuba, polyroots = results

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,9 @@
 using Test, UUIDs
 using PackageAnalyzer
-using PackageAnalyzer: parse_project, RegistryEntry
+using PackageAnalyzer: parse_project
 using JLLWrappers
 using GitHub
+using RegistryInstances
 
 get_libpath() = get(ENV, JLLWrappers.LIBPATH_env, nothing)
 const orig_libpath = get_libpath()
@@ -11,14 +12,10 @@ const auth = GitHub.AnonymousAuth()
 
 @testset "PackageAnalyzer" begin
     general = general_registry()
-    @test isdir(general)
-    @test all(p -> isdir(p.path), find_packages())
-    @test find_package("julia") ∉ find_packages()
-    @test all(p -> isdir(p.path), find_packages("Flux"))
-    @test isdir(find_package("Flux").path)
+    @test general isa RegistryInstance
     # Test some properties of the `Measurements` package.  NOTE: they may change
     # in the future!
-    measurements = analyze(RegistryEntry(joinpath(general, "M", "Measurements")); auth)
+    measurements = analyze(find_package("Measurements"); auth)
     @test measurements.uuid == UUID("eff96d63-e80a-5855-80a2-b1b0885c5ab7")
     @test measurements.reachable
     @test measurements.docs
@@ -26,21 +23,22 @@ const auth = GitHub.AnonymousAuth()
     @test !measurements.buildkite
     @test !isempty(measurements.lines_of_code)
     # Test results of a couple of packages.  Same caveat as above
-    packages = [RegistryEntry(joinpath(general, p...)) for p in (("C", "Cuba"), ("P", "PolynomialRoots"))]
+    uuids = only.(uuids_from_name.(Ref(general), ["Cuba", "PolynomialRoots"]))
+    packages = [general.pkgs[uuids[1]], general.pkgs[uuids[2]]]
     @test Set(packages) == Set(find_packages("Cuba", "PolynomialRoots")) == Set(find_packages(["Cuba", "PolynomialRoots"]))
     @test packages ⊆ find_packages()
     results = analyze(packages; auth)
     cuba, polyroots = results
     @test length(filter(p -> p.reachable, results)) == 2
     @test length(filter(p -> p.runtests, results)) == 2
-    @test cuba.drone
+    @test cuba.cirrus
     @test !polyroots.docs # Documentation is in the README!
     # We can also use broadcasting!
     @test Set(results) == Set(analyze.(packages; auth))
 
     # Test `analyze!` directly
     mktempdir() do root
-        measurements2 = analyze!(root, RegistryEntry(joinpath(general, "M", "Measurements")); auth)
+        measurements2 = analyze!(root, find_package("Measurements"); auth)
         @test isequal(measurements, measurements2)
         @test isdir(joinpath(root, "eff96d63-e80a-5855-80a2-b1b0885c5ab7")) # not cleaned up yet
     end
@@ -70,7 +68,7 @@ end
 
     # the tests folder isn't a package!
     # But this helps catch issues in error paths for when things go wrong
-    bad_pkg = analyze("."; auth)
+    bad_pkg = analyze(@__DIR__; auth)
     @test bad_pkg.repo == ""
     @test bad_pkg.uuid == UUID(UInt128(0))
     @test !bad_pkg.cirrus
@@ -172,11 +170,11 @@ end
 
     # has `license = "MIT"`
     project_1 = (; name = "PackageAnalyzer", uuid = UUID("e713c705-17e4-4cec-abe0-95bf5bf3e10c"), licenses_in_project=["MIT"])
-    @test parse_project("license_in_project") == project_1
+    @test parse_project(joinpath(@__DIR__, "license_in_project")) == project_1
 
     # has `license = ["MIT", "GPL"]`
     project_2 = (; name = "PackageAnalyzer", uuid = UUID("e713c705-17e4-4cec-abe0-95bf5bf3e10c"), licenses_in_project=["MIT", "GPL"])
-    @test parse_project("licenses_in_project") == project_2
+    @test parse_project(joinpath(@__DIR__, "licenses_in_project")) == project_2
 end
 
 @testset "`show`" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,9 +24,9 @@ const auth = GitHub.AnonymousAuth()
     @test !isempty(measurements.lines_of_code)
     # Test results of a couple of packages.  Same caveat as above
     uuids = only.(uuids_from_name.(Ref(general), ["Cuba", "PolynomialRoots"]))
-    packages = [general.pkgs[uuids[1]], general.pkgs[uuids[2]]]
-    @test Set(packages) == Set(find_packages("Cuba", "PolynomialRoots")) == Set(find_packages(["Cuba", "PolynomialRoots"]))
-    @test packages ⊆ find_packages()
+    # We compare by UUID, since other fields may be initialized or not
+    @test Set(uuids) == Set([x.uuid for x in find_packages("Cuba", "PolynomialRoots")]) == Set([x.uuid for x in find_packages(["Cuba", "PolynomialRoots"])])
+    @test uuids ⊆ [x.uuid for x in find_packages()]
     results = analyze(packages; auth)
     cuba, polyroots = results
     @test length(filter(p -> p.reachable, results)) == 2


### PR DESCRIPTION
This allows us to work with compressed registries, and also offloads some of the parsing and path manipulation there.

I bumped it as a breaking release because we had documented `RegistryEntry`'s as a way to use PackageAnalyzer, and this drops support for them in favor of RegistryInstance's PkgEntry object.