### PR TITLE
Record the tree hash of the analyzed (sub)directory

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ LicenseCheck = "726dbf0d-6eb6-41af-b36c-cd770e0f00cc"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 Tokei_jll = "3ac119c9-1236-5556-b556-adc8150b0244"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,6 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 RegistryInstances = "2792f1a3-b283-48e8-9a74-f99dce5104f3"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
-Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 Tokei_jll = "3ac119c9-1236-5556-b556-adc8150b0244"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -136,6 +136,7 @@ struct Package
     licenses_in_project::Vector{String} # any licenses in the `license` key of the Project.toml
     lines_of_code::Vector{@NamedTuple{directory::String, language::Symbol, sublanguage::Union{Nothing, Symbol}, files::Int, code::Int, comments::Int, blanks::Int}} # table of lines of code
     contributors::Vector{@NamedTuple{login::Union{String,Missing}, id::Union{Int,Missing}, name::Union{String,Missing}, type::String, contributions::Int}} # table of contributor data
+    tree_hash::String # `git_tree_sha1` hash of the analyzed code
 end
 ```
 

--- a/src/PackageAnalyzer.jl
+++ b/src/PackageAnalyzer.jl
@@ -523,7 +523,6 @@ function analyze_path(dir::AbstractString; repo = "", reachable=true, subdir="",
     # we will look for docs, tests, license, and count lines of code
     # in the `pkgdir`; we will look for CI in the `dir`.
     pkgdir = joinpath(dir, subdir)
-    tree_hash = bytes2hex(Pkg.GitTools.tree_hash(pkgdir))
     name, uuid, licenses_in_project = parse_project(pkgdir)
     docs = isfile(joinpath(pkgdir, "docs", "make.jl")) || isfile(joinpath(pkgdir, "doc", "make.jl"))
     runtests = isfile(joinpath(pkgdir, "test", "runtests.jl"))
@@ -558,6 +557,12 @@ function analyze_path(dir::AbstractString; repo = "", reachable=true, subdir="",
     else
         license_files = LicenseTableEltype[]
         lines_of_code = LoCTableEltype[]
+    end
+
+    if isdir(pkgdir)
+        tree_hash = bytes2hex(Pkg.GitTools.tree_hash(pkgdir))
+    else
+        tree_hash = ""
     end
 
     # If the repository is on GitHub and we have a non-anonymous GitHub

--- a/src/PackageAnalyzer.jl
+++ b/src/PackageAnalyzer.jl
@@ -66,7 +66,7 @@ function Package(name, uuid, repo;
                  lines_of_code=LoCTableEltype[],
                  contributors=ContributionTableElType[],
                  tree_hash=""
-)
+                 )
     return Package(name, uuid, repo, subdir, reachable, docs, runtests, github_actions, travis,
                    appveyor, cirrus, circle, drone, buildkite, azure_pipelines, gitlab_pipeline,
                    license_files, licenses_in_project, lines_of_code, contributors, tree_hash)
@@ -571,7 +571,7 @@ function analyze_path(dir::AbstractString; repo = "", reachable=true, subdir="",
 
     Package(name, uuid, repo; subdir, reachable, docs, runtests, travis, appveyor, cirrus,
             circle, drone, buildkite, azure_pipelines, gitlab_pipeline, github_actions,
-        license_files, licenses_in_project, lines_of_code, contributors, tree_hash)
+            license_files, licenses_in_project, lines_of_code, contributors, tree_hash)
 end
 
 function contribution_table(repo_name; auth)

--- a/src/PackageAnalyzer.jl
+++ b/src/PackageAnalyzer.jl
@@ -46,6 +46,7 @@ struct Package
     licenses_in_project::Vector{String} # any licenses in the `license` key of the Project.toml
     lines_of_code::Vector{LoCTableEltype} # table of lines of code
     contributors::Vector{ContributionTableElType} # table of contributor data
+    tree_hash::String
 end
 function Package(name, uuid, repo;
                  subdir="",

--- a/src/PackageAnalyzer.jl
+++ b/src/PackageAnalyzer.jl
@@ -60,20 +60,11 @@ function Package(name, uuid, repo;
                  licenses_in_project=String[],
                  lines_of_code=LoCTableEltype[],
                  contributors=ContributionTableElType[],
-                 )
+    tree_hash=""
+)
     return Package(name, uuid, repo, subdir, reachable, docs, runtests, github_actions, travis,
-                   appveyor, cirrus, circle, drone, buildkite, azure_pipelines, gitlab_pipeline,
-                   license_files, licenses_in_project, lines_of_code, contributors)
-end
-
-"""
-    RegistryEntry(path::String)
-
-Light data structure pointing to the directory where an entry of a registry is
-stored.
-"""
-struct RegistryEntry
-    path::String
+        appveyor, cirrus, circle, drone, buildkite, azure_pipelines, gitlab_pipeline,
+        license_files, licenses_in_project, lines_of_code, contributors, tree_hash)
 end
 
 # define `isequal`, `==`, and `hash` just in terms of the fields
@@ -521,6 +512,7 @@ function analyze_path(dir::AbstractString; repo = "", reachable=true, subdir="",
     # we will look for docs, tests, license, and count lines of code
     # in the `pkgdir`; we will look for CI in the `dir`.
     pkgdir = joinpath(dir, subdir)
+    tree_hash = bytes2hex(Pkg.GitTools.tree_hash(pkgdir))
     name, uuid, licenses_in_project = parse_project(pkgdir)
     docs = isfile(joinpath(pkgdir, "docs", "make.jl")) || isfile(joinpath(pkgdir, "doc", "make.jl"))
     runtests = isfile(joinpath(pkgdir, "test", "runtests.jl"))
@@ -569,7 +561,7 @@ function analyze_path(dir::AbstractString; repo = "", reachable=true, subdir="",
 
     Package(name, uuid, repo; subdir, reachable, docs, runtests, travis, appveyor, cirrus,
             circle, drone, buildkite, azure_pipelines, gitlab_pipeline, github_actions,
-            license_files, licenses_in_project, lines_of_code, contributors)
+        license_files, licenses_in_project, lines_of_code, contributors, tree_hash)
 end
 
 function contribution_table(repo_name; auth)

--- a/src/PackageAnalyzer.jl
+++ b/src/PackageAnalyzer.jl
@@ -65,11 +65,11 @@ function Package(name, uuid, repo;
                  licenses_in_project=String[],
                  lines_of_code=LoCTableEltype[],
                  contributors=ContributionTableElType[],
-    tree_hash=""
+                 tree_hash=""
 )
     return Package(name, uuid, repo, subdir, reachable, docs, runtests, github_actions, travis,
-        appveyor, cirrus, circle, drone, buildkite, azure_pipelines, gitlab_pipeline,
-        license_files, licenses_in_project, lines_of_code, contributors, tree_hash)
+                   appveyor, cirrus, circle, drone, buildkite, azure_pipelines, gitlab_pipeline,
+                   license_files, licenses_in_project, lines_of_code, contributors, tree_hash)
 end
 
 # define `isequal`, `==`, and `hash` just in terms of the fields

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -153,6 +153,7 @@ end
     # this package doesn't exist in the repo anymore; let's ensure it doesn't throw
     snoop_compile_analysis = analyze(find_package("SnoopCompileAnalysis"); auth)
     @test isempty(snoop_compile_analysis.lines_of_code)
+    @test isempty(snoop_compile_analysis.tree_hash)
 end
 
 @testset "`parse_project`" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,7 @@ const auth = GitHub.AnonymousAuth()
     @test measurements.reachable
     @test measurements.docs
     @test measurements.runtests
+    @test !isempty(measurements.tree_hash)
     @test !measurements.buildkite
     @test !isempty(measurements.lines_of_code)
     packages = find_packages("Cuba", "PolynomialRoots")


### PR DESCRIPTION
This adds a `tree_hash` field to `Package` which records the analyzed tree hash. My ultimate goal is to analyze a Manifest, and actually analyze the code according to the tree hashes in the manifest. But I think one first step is to just record the version that was actually analyzed.

In general, since we do a shallow clone of the latest version, the tree hash we get won't match the tree hash of a registered version. But if the package has happened to register the latest commit, we do get the correct hash:
```julia
using PackageAnalyzer, RegistryInstances
name = "RegistryCI"
pkg = find_package(name)
info = registry_info(pkg)
v = maximum(keys(info.version_info))
hash = bytes2hex(info.version_info[v].git_tree_sha1.bytes)
result = analyze(pkg)
result.tree_hash == hash
```

I don't want to add this to the tests bc it depends on the state of a random package, but at least it's confirmation that we are measuring the right thing here.

BTW this even works for packages in subdirectories whose trunk has progressed since they were last registered; replace "RegistryCI" with "SnoopCompileCore" to see.

This does introduce a dependence on the internals `Pkg.GitTools.tree_hash`. However this has at least been unchanged since 1.6. I am thinking perhaps we can pull it out like RegistryInstances.jl if it becomes unstable at some point in the future.