### PR TITLE
perf bugfix: only get line number, not col

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PackageAnalyzer"
 uuid = "e713c705-17e4-4cec-abe0-95bf5bf3e10c"
 authors = ["Mosè Giordano <mose@gnu.org>"]
-version = "3.0.0"
+version = "3.0.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/LineCategories.jl
+++ b/src/LineCategories.jl
@@ -3,7 +3,7 @@
 module CategorizeLines
 export LineCategories, LineCategory, Blank, Code, Docstring, Comment, categorize_lines!
 
-using JuliaSyntax: GreenNode, is_trivia, haschildren, is_error, children, span, SourceFile, source_location, Kind, kind, @K_str
+using JuliaSyntax: GreenNode, is_trivia, haschildren, is_error, children, span, SourceFile, Kind, kind, @K_str, source_line
 
 # Every line will have a single category. This way the total number across all categories
 # equals the total number of lines. This is useful for debugging and is reassuring to users.
@@ -80,7 +80,7 @@ end
 # Based on the recursive printing code for GreenNode's
 # Here, instead of printing, we update our line number information.
 function categorize_lines!(d::LineCategories, node, source, nesting=0, pos=1, parent_kind=nothing)
-    starting_line, _ = source_location(source, pos)
+    starting_line = source_line(source, pos)
     k = kind(node)
 
     # Recurse over children
@@ -92,7 +92,7 @@ function categorize_lines!(d::LineCategories, node, source, nesting=0, pos=1, pa
             categorize_lines!(d, x, source, new_nesting, p, k)
             p += x.span
         end
-        ending_line, _ = source_location(source, p)
+        ending_line = source_line(source, p)
     else
         ending_line = starting_line
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -162,18 +162,18 @@ PackageAnalyzer.CATCH_EXCEPTIONS[] = false
     end
 
     @testset "`find_packages` with `analyze`" begin
-        results = analyze_packages(find_packages("DataFrames", "Flux"); auth) # this method is threaded
+        results = analyze_packages(find_packages("DataFrames", "DSP"); auth) # this method is threaded
         @test results isa Vector{PackageV1}
         @test length(results) == 2
         test_serialization(results)
-        # DataFrames currently has 16k LoC; Flux has 5k. Let's check that they aren't mixed up
+        # DataFrames currently has 16k LoC; DSP has 4.5k. Let's check that they aren't mixed up
         # due to some kind of race condition.
         @test results[1].name == "DataFrames"
         @test PackageAnalyzer.sum_julia_loc(results[1], "src") > 10000
         @test PackageAnalyzer.sum_doc_lines(results[1]) > 5000
         @test PackageAnalyzer.sum_readme_lines(results[1]) > 5
 
-        @test results[2].name == "Flux"
+        @test results[2].name == "DSP"
         @test PackageAnalyzer.sum_julia_loc(results[2].lines_of_code, "src") < 14000
 
 


### PR DESCRIPTION
```julia
julia> @time analyze("WinEncoding");
  4.360394 seconds (61.29 k allocations: 26.116 MiB)
```
still slow, but down from a reported 5 mins