### PR TITLE
Add support for package extensions in `show` method

### DIFF
--- a/src/PackageAnalyzer.jl
+++ b/src/PackageAnalyzer.jl
@@ -183,17 +183,20 @@ function Base.show(io::IO, p::PackageV1)
         """
         if !isempty(p.lines_of_code)
             l_src = sum_julia_loc(p, "src")
+            l_ext = sum_julia_loc(p, "ext")
             l_test = sum_julia_loc(p, "test")
             l_docs = sum_doc_lines(p)
             l_readme = sum_readme_lines(p)
 
-            p_test = @sprintf("%.1f", 100 * l_test / (l_test + l_src))
-            p_docs = @sprintf("%.1f", 100 * l_docs / (l_docs + l_src))
+            p_ext = @sprintf("%.1f", 100 * l_ext / (l_test + l_src + l_ext))
+            p_test = @sprintf("%.1f", 100 * l_test / (l_test + l_src + l_ext))
+            p_docs = @sprintf("%.1f", 100 * l_docs / (l_docs + l_src + l_ext))
 
             body *= """
                   * Julia code in `src`: $(l_src) lines
-                  * Julia code in `test`: $(l_test) lines ($(p_test)% of `test` + `src`)
-                  * documentation in `docs`: $(l_docs) lines ($(p_docs)% of `docs` + `src`)
+                  * Julia code in `ext`: $(l_ext) lines ($(p_ext)% of `test` + `src` + `ext`)
+                  * Julia code in `test`: $(l_test) lines ($(p_test)% of `test` + `src` + `ext`)
+                  * documentation in `docs`: $(l_docs) lines ($(p_docs)% of `docs` + `src` + `ext`)
                 """
 
             l_src_docstring = sum_docstrings(p, "src")


### PR DESCRIPTION
This PR adds support for [package extensions](https://pkgdocs.julialang.org/v1.9/creating-packages/#Conditional-loading-of-code-in-packages-(Extensions)) by counting lines in the `ext` directory.

**Before this PR**
```julia
julia> using PackageAnalyzer

julia> analyze("https://github.com/hyrodium/BasicBSpline.jl")
PackageV1 BasicBSpline:
  * repo: https://github.com/hyrodium/BasicBSpline.jl
  * uuid: 4c5d9882-2acf-4ea4-9e48-968fd4518195
  * version: missing
  * is reachable: true
  * tree hash: 9b4f65180a415c9a61975b1dafaee2cdd07011d1
  * Julia code in `src`: 2444 lines
  * Julia code in `test`: 1828 lines (42.8% of `test` + `src`)
  * documentation in `docs`: 1237 lines (33.6% of `docs` + `src`)
  * documentation in README & docstrings: 348 lines (12.5% of README + `src`)
  * has license(s) in file: MIT
    * filename: LICENSE
    * OSI approved: true
  * has `docs/make.jl`: true
  * has `test/runtests.jl`: true
  * has continuous integration: true
    * GitHub Actions
```

**After this PR**
```julia
julia> using PackageAnalyzer

julia> analyze("https://github.com/hyrodium/BasicBSpline.jl")
PackageV1 BasicBSpline:
  * repo: https://github.com/hyrodium/BasicBSpline.jl
  * uuid: 4c5d9882-2acf-4ea4-9e48-968fd4518195
  * version: missing
  * is reachable: true
  * tree hash: 9b4f65180a415c9a61975b1dafaee2cdd07011d1
  * Julia code in `src`: 2444 lines
  * Julia code in `ext`: 161 lines (3.6% of `test` + `src` + `ext`)
  * Julia code in `test`: 1828 lines (41.2% of `test` + `src` + `ext`)
  * documentation in `docs`: 1237 lines (32.2% of `docs` + `src` + `ext`)
  * documentation in README & docstrings: 348 lines (12.5% of README + `src`)
  * has license(s) in file: MIT
    * filename: LICENSE
    * OSI approved: true
  * has `docs/make.jl`: true
  * has `test/runtests.jl`: true
  * has continuous integration: true
    * GitHub Actions
```