### PR TITLE
Remove unnecessary explicit imports

### DIFF
--- a/src/LineCategories.jl
+++ b/src/LineCategories.jl
@@ -3,7 +3,7 @@
 module CategorizeLines
 export LineCategories, LineCategory, Blank, Code, Docstring, Comment, categorize_lines!
 
-using JuliaSyntax: GreenNode, is_trivia, haschildren, is_error, children, span, SourceFile, Kind, kind, @K_str, source_line
+using JuliaSyntax: haschildren, children, SourceFile, kind, @K_str, source_line
 
 # Every line will have a single category. This way the total number across all categories
 # equals the total number of lines. This is useful for debugging and is reassuring to users.

--- a/src/PackageAnalyzer.jl
+++ b/src/PackageAnalyzer.jl
@@ -13,7 +13,7 @@ using Tar
 using CodecZlib
 using AbstractTrees
 using JuliaSyntax
-using JuliaSyntax: @K_str, kind
+using JuliaSyntax: @K_str
 using Legolas
 using Legolas: @schema, @version
 
@@ -268,7 +268,7 @@ end
 # They may ask for a specific version, which we treat like release.
 """
     abstract type PkgSource
-    
+
 Represents the installed version of a package, e.g. a release from a registry, or a `Pkg.add`'d package, or a `Pkg.dev`'d package.
 """
 abstract type PkgSource end

--- a/src/count_loc.jl
+++ b/src/count_loc.jl
@@ -1,7 +1,6 @@
 #####
 ##### Entrypoint & helpers
 #####
-using JuliaSyntax: SourceFile
 
 # Entrypoint
 function count_lines_of_code(dir)


### PR DESCRIPTION
Found via https://ericphanson.github.io/ExplicitImports.jl/dev/api/#ExplicitImports.print_explicit_imports

````julia
julia> using PackageAnalyzer, ExplicitImports

julia> print_explicit_imports(PackageAnalyzer)
Module PackageAnalyzer is relying on implicit imports for 10 names. These could be explicitly imported as follows:

```julia
using CodecZlib: GzipDecompressorStream
using LicenseCheck: find_licenses
using LicenseCheck: is_osi_approved
using PackageAnalyzer.CategorizeLines: Blank
using PackageAnalyzer.CategorizeLines: Code
using PackageAnalyzer.CategorizeLines: Comment
using PackageAnalyzer.CategorizeLines: Docstring
using PackageAnalyzer.CategorizeLines: LineCategories
using PackageAnalyzer.CategorizeLines: LineCategory
using PackageAnalyzer.CategorizeLines: categorize_lines!
```

Additionally PackageAnalyzer has stale explicit imports for these unused names:
SourceFile
kind

Module PackageAnalyzer.CategorizeLines is not relying on any implicit imports.

Additionally PackageAnalyzer.CategorizeLines has stale explicit imports for these unused names:
GreenNode
Kind
is_error
is_trivia
span
````