### PR TITLE
Add zenodo DOI to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://github.com/JuliaEcosystem/PackageAnalyzer.jl/workflows/CI/badge.svg)](https://github.com/JuliaEcosystem/PackageAnalyzer.jl/actions?query=workflow%3ACI)
 [![](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliaecosystem.github.io/PackageAnalyzer.jl/dev/)
+[![DOI](https://zenodo.org/badge/332265222.svg)](https://zenodo.org/doi/10.5281/zenodo.10835825)
 
 # PackageAnalyzer
 


### PR DESCRIPTION
closes #99 

I first added Zenodo oauth access for JuliaEcosystem, then turned it on for this repo, then used [this script](https://github.com/zenodo/zenodo/issues/1463#issuecomment-1007602828) to submit our latest existing release (rather than making a new tag).