### PR TITLE
CI: Add Julia 1.10 (the current LTS) to the CI matrix; also, drop support for 1.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - "1.6"
+          - "1.6" # previous LTS
           - "1.10"
           - "nightly"
         os:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         julia-version:
           - "1.6" # previous LTS
-          - "1.10"
+          - "1.10" # current LTS
           - "nightly"
         os:
           - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - "1.6" # previous LTS
           - "1.10" # current LTS
           - "nightly"
         os:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       matrix:
         julia-version:
           - "1.6"
+          - "1.10"
           - "nightly"
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -31,7 +31,7 @@ JSON3 = "1.5.1"
 JuliaSyntax = "0.4"
 LicenseCheck = "0.2"
 RegistryInstances = "0.1"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 JLLWrappers = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"


### PR DESCRIPTION
Before this PR, CI runs on the following Julia versions:
- 1.6 (previous LTS)
- nightly

After this PR, CI runs on the following Julia versions:
- 1.6 (previous LTS)
- 1.10 (current LTS)
- nightly